### PR TITLE
Fix -Wimplicit-function-declaration in md5.c and lam.c

### DIFF
--- a/src/bin/md5/md5.c
+++ b/src/bin/md5/md5.c
@@ -36,6 +36,7 @@
 #include <time.h>
 #include <unistd.h>
 #include <errno.h>
+#include <util.h>
 
 #include <md5.h>
 #include <rmd160.h>

--- a/src/liboutils/include/util.h
+++ b/src/liboutils/include/util.h
@@ -10,4 +10,5 @@ int	RAND_bytes(unsigned char *, int);
 int	b64_ntop(u_char const *, size_t, char *, size_t);
 int	b64_pton(char const *, u_char *target, size_t);
 void *	reallocarray(void *, size_t, size_t);
+void *	recallocarray(void *, size_t, size_t, size_t);
 

--- a/src/usr.bin/lam/lam.c
+++ b/src/usr.bin/lam/lam.c
@@ -45,6 +45,7 @@
 #include <limits.h>
 #include <string.h>
 #include <unistd.h>
+#include <util.h>
 
 #define	BIGBUFSIZ	5 * BUFSIZ
 


### PR DESCRIPTION
This upstreams a patch we had in [Alpine downstream for a while](https://git.alpinelinux.org/aports/commit/?id=46aa839481c0242f08b12ce590b2f1404b18c8d6).

This patch fixes two implicit function declaration warnings:

1. `lam.c` uses recallocarray from `recallocarray.c` for which no function prototype was provided previously. Similar to reallocarray such a function prototype is now provided in `util.h` and `lam.c` has been modified to include this file.
2. `md5.c` uses b64_ntop but, contrary to other users of this function (e.g. signify), does not include `util.h` which provides the function prototype for b64_ntop.

Note that [implicit function declarations can affect code generation](https://wiki.gentoo.org/wiki/Modern_C_porting#Is_this_cosmetic.3F) so it would be cool to get this fixed upstream :)